### PR TITLE
adding correlation id response header

### DIFF
--- a/cmd/kanalictl/app/decrypt.go
+++ b/cmd/kanalictl/app/decrypt.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Northwestern Mutual.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package app
 
 import (

--- a/cmd/kanalictl/app/generate.go
+++ b/cmd/kanalictl/app/generate.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Northwestern Mutual.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package app
 
 import (

--- a/cmd/kanalictl/app/options/decrypt.go
+++ b/cmd/kanalictl/app/options/decrypt.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Northwestern Mutual.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package options
 
 import (

--- a/cmd/kanalictl/app/options/generate.go
+++ b/cmd/kanalictl/app/options/generate.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Northwestern Mutual.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package options
 
 import (

--- a/cmd/kanalictl/main.go
+++ b/cmd/kanalictl/main.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Northwestern Mutual.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package main
 
 import (

--- a/hack/kanali-up.sh
+++ b/hack/kanali-up.sh
@@ -32,4 +32,4 @@ kanali start \
   --proxy.enable_mock_responses=true \
   --proxy.tls_common_name_validation=true \
   --plugins.apiKey.header_key="apikey" \
-  --plugins.apiKey.decryption_key_file=$KANALI_PLUGINS_APIKEY_DECRYPTION_KEY_FILE
+  --plugins.apiKey.decryption_key_file=$TEMP_RSA_DIR/private.pem

--- a/pkg/flow/validateproxy.go
+++ b/pkg/flow/validateproxy.go
@@ -64,6 +64,6 @@ func (step validateProxyStep) Do(ctx context.Context, w http.ResponseWriter, r *
 		return next()
 	}
 
-	logger.Warn(errors.ErrorProxyNotFound.Message)
+	logger.Info(errors.ErrorProxyNotFound.Message)
 	return errors.ErrorProxyNotFound
 }

--- a/pkg/middleware/correlation.go
+++ b/pkg/middleware/correlation.go
@@ -35,8 +35,10 @@ import (
 // execeted before other middleware.
 func Correlation(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := log.NewContext(r.Context(), zap.Stringer(tags.HTTPRequestCorrelationId, uuid.NewV4()))
+		id := uuid.NewV4()
+		ctx := log.NewContext(r.Context(), zap.Stringer(tags.HTTPRequestCorrelationId, id))
 		log.WithContext(ctx).Debug("established new correlation id for this request")
+		w.Header().Set(tags.HeaderResponseCorrelationID, id.String())
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/pkg/middleware/metrics.go
+++ b/pkg/middleware/metrics.go
@@ -43,6 +43,13 @@ func Metrics(next http.Handler) http.Handler {
 
 		rec := httptest.NewRecorder()
 
+		// This is a workaround until a proper
+		// middleware where the errors fall through
+		// is implemented.
+		for k, v := range w.Header() {
+			rec.Header()[k] = v
+		}
+
 		metrics.RequestInFlightCount.Inc()
 
 		next.ServeHTTP(rec, r)

--- a/pkg/tags/headers.go
+++ b/pkg/tags/headers.go
@@ -1,0 +1,5 @@
+package tags
+
+const (
+	HeaderResponseCorrelationID = "X-Kanali-Correlation-Id"
+)


### PR DESCRIPTION
```
$ curl -i localhost:8080
HTTP/1.1 404 Not Found
Content-Type: application/json
X-Kanali-Correlation-Id: d0fb44cc-86f6-4eb7-8e8a-0ccd9da1c8eb
Date: Wed, 02 May 2018 21:35:41 GMT
Content-Length: 173

{"status":404,"message":"No ApiProxy resource was not found that matches the request.","code":0,"details":"Visit https://kanali.io/docs/v2/errorcodes/#00 for more details."}
```