### PR TITLE
Add support for setting the nodeport for the kanali gateway service

### DIFF
--- a/helm/kanali/README.md
+++ b/helm/kanali/README.md
@@ -28,8 +28,10 @@ $ helm del --purge my-release
 | `kanali.namespace`                        | Namespace for Kanali resources                       | default                   |
 | `kanali.logLevel`                         | Log level                                            | info                      |
 | `kanali.gateway.securePort`               | HTTPS server port                                    | 8443                      |
+| `kanali.gateway.secureNodePort`           | HTTPS external NodePort                              | 0 (disabled)              |
 | `kanali.gateway.secureBindAddress`        | HTTP server bind address                             | 0.0.0.0                   |
 | `kanali.gateway.insecurePort`             | HTTP server port                                     | 0 (disabled)              |
+| `kanali.gateway.insecureNodePort`         | HTTP external NodePort                               | 0 (disabled)              |
 | `kanali.gateway.insecureBindAddress`      | HTTP server bind address                             | 0.0.0.0                   |
 | `kanali.gateway.rsa.secretName`           | Secret containing private key for API key decryption | kanali-rsa                |
 | `kanali.gateway.tls.secretName`           | Secret containing tls assets for HTTPS server        | kanali-pki                |

--- a/helm/kanali/templates/service-kanali.yaml
+++ b/helm/kanali/templates/service-kanali.yaml
@@ -19,9 +19,15 @@ spec:
   {{- if .Values.kanali.gateway.securePort }}
   - name: https
     port: {{.Values.kanali.gateway.securePort}}
+    {{- if .Values.kanali.gateway.secureNodePort }}
+    nodePort: {{.Values.kanali.gateway.secureNodePort}}
+    {{- end }}
   {{- end }}
   {{- if .Values.kanali.gateway.insecurePort }}
   - name: http
     port: {{.Values.kanali.gateway.insecurePort}}
+    {{- if .Values.kanali.gateway.insecureNodePort }}
+    nodePort: {{.Values.kanali.gateway.insecureNodePort}}
+    {{- end }}
   {{- end }}
   type: NodePort

--- a/helm/kanali/values.yaml
+++ b/helm/kanali/values.yaml
@@ -20,8 +20,10 @@ kanali:
   logLevel: info
   gateway:
     securePort: 8443
+    secureNodePort: 0
     secureBindAddress: 0.0.0.0
     insecurePort: 0
+    insecureNodePort: 0
     insecureBindAddress: 0.0.0.0
     rsa:
       secretName: kanali-rsa


### PR DESCRIPTION
This adds support for setting a specific nodeport to the kanali gateway service.  This can be handy when using external load balancers without having to query the service for the nodeport.