### PR TITLE
adding kanalictl to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,6 @@ FROM alpine:${ALPINE_VERSION}
 LABEL maintainer="frankgreco@northwesternmutual.com"
 LABEL version="${VERSION}"
 COPY --from=BUILD /go/bin/kanali /
+COPY --from=BUILD /go/bin/kanalictl /
 COPY --from=BUILD /go/bin/validator /
 COPY --from=BUILD /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
This PR adds the `kanalictl` binary to the container image so that the following is possible:

```sh
$ docker run northwesternmutual/hyperkanali:latest /kanalictl -h
Command line interface for Kanali.

Usage:
  kanalictl [command]

Available Commands:
  apikey      Preforms operations on API key resources
  help        Help about any command
  version     Version information

Flags:
  -h, --help   help for kanalictl

Use "kanalictl [command] --help" for more information about a command.
```