### PR TITLE
Removing kanali.io redirect.

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-kanali.io


### PR DESCRIPTION
Removing kanali.io as a redirect.